### PR TITLE
Add Nomad ShippingReturns Magento module

### DIFF
--- a/app/code/Nomad/ShippingReturns/Block/Promotions.php
+++ b/app/code/Nomad/ShippingReturns/Block/Promotions.php
@@ -1,0 +1,12 @@
+<?php
+namespace Nomad\ShippingReturns\Block;
+
+use Magento\Framework\View\Element\Template;
+
+class Promotions extends Template
+{
+    public function getMessage()
+    {
+        return __('Free shipping on orders over $50!');
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Block/ReturnForm.php
+++ b/app/code/Nomad/ShippingReturns/Block/ReturnForm.php
@@ -1,0 +1,24 @@
+<?php
+namespace Nomad\ShippingReturns\Block;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\Data\Form\FormKey\Validator;
+
+class ReturnForm extends Template
+{
+    private $formKey;
+
+    public function __construct(
+        Template\Context $context,
+        Validator $formKey,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->formKey = $formKey;
+    }
+
+    public function getFormKey()
+    {
+        return $this->formKey->getFormKey();
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Controller/Adminhtml/Request/Index.php
+++ b/app/code/Nomad/ShippingReturns/Controller/Adminhtml/Request/Index.php
@@ -1,0 +1,26 @@
+<?php
+namespace Nomad\ShippingReturns\Controller\Adminhtml\Request;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    const ADMIN_RESOURCE = 'Nomad_ShippingReturns::requests';
+    private $resultPageFactory;
+
+    public function __construct(Context $context, PageFactory $resultPageFactory)
+    {
+        parent::__construct($context);
+        $this->resultPageFactory = $resultPageFactory;
+    }
+
+    public function execute()
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('Nomad_ShippingReturns::requests');
+        $resultPage->getConfig()->getTitle()->prepend(__('Return Requests'));
+        return $resultPage;
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Controller/Index/Submit.php
+++ b/app/code/Nomad/ShippingReturns/Controller/Index/Submit.php
@@ -1,0 +1,46 @@
+<?php
+namespace Nomad\ShippingReturns\Controller\Index;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Nomad\ShippingReturns\Model\ReturnRequestFactory;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Controller\Result\RedirectFactory;
+
+class Submit extends Action
+{
+    private $returnRequestFactory;
+    private $customerSession;
+    private $resultRedirectFactory;
+
+    public function __construct(
+        Context $context,
+        ReturnRequestFactory $returnRequestFactory,
+        CustomerSession $customerSession,
+        RedirectFactory $resultRedirectFactory
+    ) {
+        parent::__construct($context);
+        $this->returnRequestFactory = $returnRequestFactory;
+        $this->customerSession = $customerSession;
+        $this->resultRedirectFactory = $resultRedirectFactory;
+    }
+
+    public function execute()
+    {
+        $data = $this->getRequest()->getPostValue();
+        if (!isset($data['order_id'])) {
+            return $this->resultRedirectFactory->create()->setPath('*/*');
+        }
+
+        $model = $this->returnRequestFactory->create();
+        $model->setData([
+            'order_id' => $data['order_id'],
+            'customer_id' => $this->customerSession->getCustomerId(),
+            'status' => 'pending'
+        ]);
+        $model->save();
+
+        $this->messageManager->addSuccessMessage(__('Return request submitted.'));
+        return $this->resultRedirectFactory->create()->setPath('*/*');
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Model/Carrier/NomadShipping.php
+++ b/app/code/Nomad/ShippingReturns/Model/Carrier/NomadShipping.php
@@ -1,0 +1,69 @@
+<?php
+namespace Nomad\ShippingReturns\Model\Carrier;
+
+use Magento\Shipping\Model\Carrier\AbstractCarrier;
+use Magento\Shipping\Model\Carrier\CarrierInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Shipping\Model\Rate\ResultFactory;
+use Magento\Shipping\Model\Rate\Result\MethodFactory;
+use Psr\Log\LoggerInterface;
+
+class NomadShipping extends AbstractCarrier implements CarrierInterface
+{
+    protected $_code = 'nomadshipping';
+    protected $_rateResultFactory;
+    protected $_rateMethodFactory;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        ResultFactory $rateResultFactory,
+        MethodFactory $rateMethodFactory,
+        LoggerInterface $logger,
+        array $data = []
+    ) {
+        $this->_rateResultFactory = $rateResultFactory;
+        $this->_rateMethodFactory = $rateMethodFactory;
+        parent::__construct($scopeConfig, $logger, $data);
+    }
+
+    public function collectRates(\Magento\Quote\Model\Quote\Address\RateRequest $request)
+    {
+        if (!$this->getConfigFlag('active')) {
+            return false;
+        }
+
+        $result = $this->_rateResultFactory->create();
+        $method = $this->_rateMethodFactory->create();
+
+        $method->setCarrier($this->_code);
+        $method->setCarrierTitle($this->getConfigData('title'));
+        $method->setMethod($this->_code);
+        $method->setMethodTitle($this->getConfigData('title'));
+
+        $price = $this->getShippingPrice($request);
+
+        $method->setPrice($price);
+        $method->setCost($price);
+        $result->append($method);
+
+        return $result;
+    }
+
+    public function getAllowedMethods()
+    {
+        return [$this->_code => $this->getConfigData('title')];
+    }
+
+    private function getShippingPrice($request)
+    {
+        $mode = $this->getConfigData('mode');
+        $basePrice = (float)$this->getConfigData('price');
+
+        if ($mode === 'dynamic') {
+            $qty = array_sum($request->getPackageQty());
+            return $basePrice * max(1, $qty);
+        }
+
+        return $basePrice;
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Model/Config/Source/Mode.php
+++ b/app/code/Nomad/ShippingReturns/Model/Config/Source/Mode.php
@@ -1,0 +1,15 @@
+<?php
+namespace Nomad\ShippingReturns\Model\Config\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class Mode implements ArrayInterface
+{
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'flat', 'label' => __('Flat Rate')],
+            ['value' => 'dynamic', 'label' => __('Dynamic Rate')],
+        ];
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Model/ResourceModel/ReturnRequest.php
+++ b/app/code/Nomad/ShippingReturns/Model/ResourceModel/ReturnRequest.php
@@ -1,0 +1,12 @@
+<?php
+namespace Nomad\ShippingReturns\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class ReturnRequest extends AbstractDb
+{
+    protected function _construct()
+    {
+        $this->_init('nomad_return_request', 'entity_id');
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Model/ResourceModel/ReturnRequest/Collection.php
+++ b/app/code/Nomad/ShippingReturns/Model/ResourceModel/ReturnRequest/Collection.php
@@ -1,0 +1,14 @@
+<?php
+namespace Nomad\ShippingReturns\Model\ResourceModel\ReturnRequest;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Nomad\ShippingReturns\Model\ReturnRequest as Model;
+use Nomad\ShippingReturns\Model\ResourceModel\ReturnRequest as ResourceModel;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct()
+    {
+        $this->_init(Model::class, ResourceModel::class);
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Model/ReturnRequest.php
+++ b/app/code/Nomad/ShippingReturns/Model/ReturnRequest.php
@@ -1,0 +1,12 @@
+<?php
+namespace Nomad\ShippingReturns\Model;
+
+use Magento\Framework\Model\AbstractModel;
+
+class ReturnRequest extends AbstractModel
+{
+    protected function _construct()
+    {
+        $this->_init(ResourceModel\ReturnRequest::class);
+    }
+}

--- a/app/code/Nomad/ShippingReturns/Setup/Patch/Schema/CreateReturnRequestTable.php
+++ b/app/code/Nomad/ShippingReturns/Setup/Patch/Schema/CreateReturnRequestTable.php
@@ -1,0 +1,55 @@
+<?php
+namespace Nomad\ShippingReturns\Setup\Patch\Schema;
+
+use Magento\Framework\Setup\Patch\PatchVersionInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class CreateReturnRequestTable implements DataPatchInterface, PatchVersionInterface
+{
+    private $moduleDataSetup;
+
+    public function __construct(ModuleDataSetupInterface $moduleDataSetup)
+    {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    public function apply()
+    {
+        $setup = $this->moduleDataSetup;
+        $setup->startSetup();
+
+        if (!$setup->tableExists('nomad_return_request')) {
+            $table = $setup->getConnection()->newTable($setup->getTable('nomad_return_request'))
+                ->addColumn('entity_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER, null, [
+                    'identity' => true,
+                    'nullable' => false,
+                    'primary' => true,
+                    'unsigned' => true,
+                ], 'Entity ID')
+                ->addColumn('order_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER, null, ['nullable' => false, 'unsigned' => true], 'Order ID')
+                ->addColumn('customer_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER, null, ['nullable' => true, 'unsigned' => true], 'Customer ID')
+                ->addColumn('status', \Magento\Framework\DB\Ddl\Table::TYPE_TEXT, 32, [], 'Status')
+                ->addColumn('created_at', \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP, null, [], 'Created At')
+                ->addColumn('updated_at', \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP, null, [], 'Updated At');
+            $setup->getConnection()->createTable($table);
+        }
+
+        $setup->endSetup();
+    }
+
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    public static function getVersion()
+    {
+        return '1.0.0';
+    }
+
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/app/code/Nomad/ShippingReturns/etc/acl.xml
+++ b/app/code/Nomad/ShippingReturns/etc/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="Magento_Sales::sales">
+                <resource id="Nomad_ShippingReturns::requests" title="Return Requests" />
+            </resource>
+        </resource>
+    </resources>
+</acl>

--- a/app/code/Nomad/ShippingReturns/etc/adminhtml/menu.xml
+++ b/app/code/Nomad/ShippingReturns/etc/adminhtml/menu.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<menu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Menu/etc/menu.xsd">
+    <add id="Nomad_ShippingReturns::requests" title="Return Requests" module="Nomad_ShippingReturns" sortOrder="100" parent="Magento_Sales::sales" action="shippingreturns/request/index" resource="Nomad_ShippingReturns::requests" />
+</menu>

--- a/app/code/Nomad/ShippingReturns/etc/adminhtml/routes.xml
+++ b/app/code/Nomad/ShippingReturns/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="shippingreturns" frontName="shippingreturns">
+            <module name="Nomad_ShippingReturns" />
+        </route>
+    </router>
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/adminhtml/system.xml
+++ b/app/code/Nomad/ShippingReturns/etc/adminhtml/system.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="carriers">
+            <group id="nomadshipping" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Nomad Shipping</label>
+                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Enabled</label>
+                    <source_model>Magento\\Config\\Model\\Config\\Source\\Yesno</source_model>
+                </field>
+                <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Title</label>
+                </field>
+                <field id="mode" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Rate Mode</label>
+                    <source_model>Nomad\\ShippingReturns\\Model\\Config\\Source\\Mode</source_model>
+                </field>
+                <field id="price" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Flat Rate Price</label>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/config.xml
+++ b/app/code/Nomad/ShippingReturns/etc/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/config.xsd">
+    <default>
+        <carriers>
+            <nomadshipping>
+                <active>1</active>
+                <title>Nomad Shipping</title>
+                <name>Nomad Shipping</name>
+                <price>10</price>
+                <sort_order>100</sort_order>
+            </nomadshipping>
+        </carriers>
+    </default>
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/di.xml
+++ b/app/code/Nomad/ShippingReturns/etc/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Shipping\Model\Config">
+        <arguments>
+            <argument name="carriers" xsi:type="array">
+                <item name="nomadshipping" xsi:type="string">Nomad\\ShippingReturns\\Model\\Carrier\\NomadShipping</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/frontend/di.xml
+++ b/app/code/Nomad/ShippingReturns/etc/frontend/di.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/frontend/routes.xml
+++ b/app/code/Nomad/ShippingReturns/etc/frontend/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="standard">
+        <route id="shippingreturns" frontName="shippingreturns">
+            <module name="Nomad_ShippingReturns" />
+        </route>
+    </router>
+</config>

--- a/app/code/Nomad/ShippingReturns/etc/module.xml
+++ b/app/code/Nomad/ShippingReturns/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Nomad_ShippingReturns" setup_version="1.0.0"/>
+</config>

--- a/app/code/Nomad/ShippingReturns/registration.php
+++ b/app/code/Nomad/ShippingReturns/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Nomad_ShippingReturns',
+    __DIR__
+);

--- a/app/code/Nomad/ShippingReturns/view/adminhtml/layout/shippingreturns_request_index.xml
+++ b/app/code/Nomad/ShippingReturns/view/adminhtml/layout/shippingreturns_request_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Magento\\Backend\\Block\\Template" template="Nomad_ShippingReturns::return/list.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Nomad/ShippingReturns/view/adminhtml/templates/return/list.phtml
+++ b/app/code/Nomad/ShippingReturns/view/adminhtml/templates/return/list.phtml
@@ -1,0 +1,22 @@
+<?php /** @var \Magento\Backend\Block\Template $block */ ?>
+<h1><?php echo __('Return Requests'); ?></h1>
+<table class="data-grid">
+    <thead>
+        <tr>
+            <th><?php echo __('ID'); ?></th>
+            <th><?php echo __('Order'); ?></th>
+            <th><?php echo __('Customer'); ?></th>
+            <th><?php echo __('Status'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($block->getRequest()->getModel()->getCollection() as $request): ?>
+        <tr>
+            <td><?php echo $request->getId(); ?></td>
+            <td><?php echo $request->getOrderId(); ?></td>
+            <td><?php echo $request->getCustomerId(); ?></td>
+            <td><?php echo $request->getStatus(); ?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>

--- a/app/code/Nomad/ShippingReturns/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="product.info.main">
+            <block class="Nomad\\ShippingReturns\\Block\\Promotions" name="nomad.promotions.product" template="Nomad_ShippingReturns::promotions.phtml" before="-" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Nomad/ShippingReturns/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="cart.summary">
+            <block class="Nomad\\ShippingReturns\\Block\\Promotions" name="nomad.promotions.cart" template="Nomad_ShippingReturns::promotions.phtml" before="-" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Nomad/ShippingReturns/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/layout/checkout_index_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Nomad\\ShippingReturns\\Block\\Promotions" name="nomad.promotions.checkout" template="Nomad_ShippingReturns::promotions.phtml" before="-" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Nomad/ShippingReturns/view/frontend/layout/shippingreturns_index_submit.xml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/layout/shippingreturns_index_submit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Nomad\\ShippingReturns\\Block\\ReturnForm" template="Nomad_ShippingReturns::returns/form.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Nomad/ShippingReturns/view/frontend/templates/promotions.phtml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/templates/promotions.phtml
@@ -1,0 +1,3 @@
+<div class="nomad-promotions">
+    <p><?php echo $block->escapeHtml($block->getMessage()); ?></p>
+</div>

--- a/app/code/Nomad/ShippingReturns/view/frontend/templates/returns/form.phtml
+++ b/app/code/Nomad/ShippingReturns/view/frontend/templates/returns/form.phtml
@@ -1,0 +1,8 @@
+<form action="<?php echo $block->getUrl('shippingreturns/index/submit'); ?>" method="post">
+    <input type="hidden" name="form_key" value="<?php echo $block->getFormKey(); ?>" />
+    <div>
+        <label><?php echo __('Order ID'); ?></label>
+        <input type="text" name="order_id" required="required" />
+    </div>
+    <button type="submit"><?php echo __('Submit Return'); ?></button>
+</form>


### PR DESCRIPTION
## Summary
- add registration and module configuration
- implement custom shipping carrier
- allow admin configuration for carrier
- create return request models and setup patch
- add frontend and admin controllers and views for return management
- include promotion box on product, cart, and checkout pages

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfd7ed27483329d2082ec88a2ae23